### PR TITLE
fix: adding missing newline for creator header

### DIFF
--- a/ontogram/__init__.py
+++ b/ontogram/__init__.py
@@ -234,8 +234,8 @@ def _get_creator(g):
         if name:
             plant_uml += f'Creator: {name} '
         if email:
-            plant_uml += f'({email}) \n'
-        plant_uml += 'endheader\n'
+            plant_uml += f'({email}) '
+        plant_uml += '\nendheader\n'
     return plant_uml
 
 


### PR DESCRIPTION
fixes corner case where no creator email can be found, resulting in a missing (but required) linebreak before `endheader` ->

wrong:
![image](https://user-images.githubusercontent.com/10495449/187355419-81266853-d11a-41ff-8f89-1a8bcafe9cdd.png)

correct:
```
header
Creator: Alice Bob 
endheader
```