### PR TITLE
feat: allows passing PlantUML statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ Options:
   --format ['turtle', 'xml', 'nt', 'n3']
                                   RDF serialization of input file. Default is
                                   turtle.
+  --header LIST                   Comma-separated list of configuration
+                                  statements, which will be split on comma and
+                                  included as a set of lines in the PlantUML's
+                                  header section.
+
   --help                          Show this message and exit.
 ```
 
@@ -58,15 +63,45 @@ Ontogram is a Python library and can be easily integrated with any existing Pyth
 ```python
 from ontogram import Ontogram
 
-# First parameter accepts a file path to the OWL ontology. 
+# First parameter accepts a file path to the OWL ontology.
 # Second parameter tells Ontogram what RDF format the OWL ontology is in.
-ontogram = Ontogram('ontology.ttl', format='turtle')
+# Third parameter allows to pass whatever list of PlantUML predicates
+# you may pass to configure the diagram.
+ontogram = Ontogram('ontology.ttl', format='turtle', headers=['left to right direction'])
 
-# Generate a PNG diagram from the OWl ontology and write to disk as 'ontology.ttl.txt'.
+# Generate a PNG diagram from the OWl ontology and write to disk as 'ontology.ttl.txt.png'.
 ontogram.png_file('ontology.ttl.txt')
 
-# Same as above, but as an SVG diagram. 
-ontogram.svg_file('ontology.ttl.svg')
+# Same as above, but as an SVG diagram 'ontology.ttl.txt.svg'.
+ontogram.svg_file('ontology.ttl.txt')
 ```
 
 See the [examples](examples) directory for example outputs.
+
+
+### Headers parameter
+
+With the `headers` parameter, you can configure the diagram shape.
+Ontogram uses the [PlantUML](https://plantuml.com) library under the hood
+to draw the output as a "class diagram".
+
+PlantUML takes a human-readable script describing the schema as an input.
+This is the `.txt` file that Ontogram produces, you can take a look at it with
+any text editor.
+PlantUML allows to add several lines in the beginning of the script,
+after the `@startuml` tag.
+
+The `headers` parameter of Ontogram allows you to pass configuration statements
+to the PlantUML script.
+For instance, to change diagram orientation, you can pass, eiher:
+- `--headers='left to right direction'`, or
+- `--headers='top to bottom direction'`.
+
+You may pass several statements, separated by a comma.
+They will be inserted as separated lines in the header section,
+for example:
+`--headers='left to right direction,scale 750 width'`
+
+See the [PlantUML](https://plantuml.com/en/guide) documentation for more
+information and configuration ideas.
+

--- a/ontogram/__init__.py
+++ b/ontogram/__init__.py
@@ -10,14 +10,18 @@ class Ontogram:
     Ontogram class accepts an OWL ontology file and provides methods
     to produce a PlantUML-based diagram.
     """
-    def __init__(self, filepath : str, format='turtle'):
+    def __init__(self, filepath : str, format='turtle', headers = []):
         """
 
         :param filepath: File path of the OWL ontology file.
         :param format: RDF serialization of the OWl ontology file. Options: ['turtle', 'xml', 'nt', 'n3'].
+        :param header: PlantUML configuration header
         """
         self.g = Graph().parse(filepath, format=format)
         self._plantuml = '@startuml\n'
+        if headers:
+            self._plantuml += '\n'.join(headers)
+            self._plantuml += '\n'
         self._plantuml += _get_ontology_title(self.g)
         self._plantuml += _get_subclass_relationship(self.g)
         self._plantuml += _get_class_definition(self.g)

--- a/ontogram/cli.py
+++ b/ontogram/cli.py
@@ -11,14 +11,22 @@ from ontogram import Ontogram
               default='turtle',
               metavar="['turtle', 'xml', 'nt', 'n3']",
               help='RDF serialization of input file. Default is turtle.')
+@click.option('--header',
+              default='',
+              metavar='LIST',
+              help="Comma-separated list of configuration statements, which will be split on comma and included as a set of lines in the PlantUML's header section.")
 @click.argument('ontology_filepath', type=click.Path(exists=True))
-def main(ontology_filepath, format):
+def main(ontology_filepath, format, header):
     """Ontogram CLI is a tool to generate a diagram from an OWL ontology file."""
-    ontogram = Ontogram(ontology_filepath, format=format)
 
-    ontogram.plantuml_file(ontology_filepath)
-    ontogram.png_file(ontology_filepath + '.txt')
-    ontogram.svg_file(ontology_filepath + '.txt')
+    headers = header.split(',')
+    print('\n'.join(headers))
+
+    ontogram = Ontogram(ontology_filepath, format=format, headers=headers)
+
+    ontogram.plantuml_file(ontology_filepath) # Saves with extension: .txt
+    ontogram.png_file(ontology_filepath + '.txt') # Saves with extension: .png
+    ontogram.svg_file(ontology_filepath + '.txt') # Saves with extension: .svg
 
 
 if __name__ == '__main__':

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 rdflib
 click
+six
 plantuml


### PR DESCRIPTION
Adds a way to pass statements that are inserted into the PlantUML script header section. Useful for configuring the output diagram.